### PR TITLE
AM5 mount set guiding speed per axis

### DIFF
--- a/src/mount/zwo.rs
+++ b/src/mount/zwo.rs
@@ -164,7 +164,7 @@ impl Mount for ZWO {
 
         send_cmd_and_get_reply(
             &mut self.serial_port,
-            format!(":Rg{:.2}#", a1_s.max(0.1)),
+            format!(":Rg{:.2}#", a1_s.max(0.9)),
             ResponseType::None
         ).map(|_| ())?;
 
@@ -173,6 +173,12 @@ impl Mount for ZWO {
         } else if axis1_speed.0 < 0.0 {
             send_cmd_and_get_reply(&mut self.serial_port, ":Mgw0500#".into(), ResponseType::None).map(|_| ())?;
         }
+
+        send_cmd_and_get_reply(
+            &mut self.serial_port,
+            format!(":Rg{:.2}#", a2_s.max(0.9)),
+            ResponseType::None
+        ).map(|_| ())?;
 
         if axis2_speed.0 > 0.0 {
             send_cmd_and_get_reply(&mut self.serial_port, ":Mgn0500#".into(), ResponseType::None).map(|_| ())?;


### PR DESCRIPTION
I have just tested the new ZWO mount feature with my AM5.

The guiding was to slow to correct the error in tracking so i tried setting the guide speed per axis and increasing the max speed to 0.9.

This has fixed the problem for me so i wanted to share my solution.

The guiding seems a bit jumpy now but it stays within the circle.

Maby this helps you improve the feature if not i won't have any hard feelings if you just close this PR.

You can also reach out to me if you need someone for testing via solarchat(LLichter).

Thanks for the great work on this tool.